### PR TITLE
Update transformers version in the user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Models can be used for inference or finetuning with two ways: 🤗HuggingFace in
 For both ways install transformers:
 
 ```bash
-pip install transformers==3.5.0
+pip install transformers==4.3.0
 ```
 
 ### HuggingFace interface

--- a/examples/Finetune_RuGPTs_with_HF.ipynb
+++ b/examples/Finetune_RuGPTs_with_HF.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "!pip install torch==1.4.0\n",
-    "!pip3 install transformers==3.5.0"
+    "!pip3 install transformers==4.3.0"
    ]
   },
   {

--- a/examples/Finetune_and_generate_RuGPTs_deepspeed_megatron.ipynb
+++ b/examples/Finetune_and_generate_RuGPTs_deepspeed_megatron.ipynb
@@ -33,7 +33,7 @@
         "id": "hu1OzWZ6zqQv"
       },
       "source": [
-        "!pip3 install transformers==3.5.0"
+        "!pip3 install transformers==4.3.0"
       ],
       "execution_count": null,
       "outputs": []

--- a/examples/Finetune_and_generate_RuGPTs_only_with_megatron.ipynb
+++ b/examples/Finetune_and_generate_RuGPTs_only_with_megatron.ipynb
@@ -33,7 +33,7 @@
         "id": "hu1OzWZ6zqQv"
       },
       "source": [
-        "!pip3 install transformers==3.5.0"
+        "!pip3 install transformers==4.3.0"
       ],
       "execution_count": null,
       "outputs": []

--- a/examples/Generate_text_with_RuGPTs_HF.ipynb
+++ b/examples/Generate_text_with_RuGPTs_HF.ipynb
@@ -21,7 +21,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip3 install transformers==3.5.0"
+    "!pip3 install transformers==4.3.0"
    ]
   },
   {

--- a/examples/ruGPT3XL_generation.ipynb
+++ b/examples/ruGPT3XL_generation.ipynb
@@ -242,7 +242,7 @@
         "id": "H2XiJvm_tQgL"
       },
       "source": [
-        "!pip install transformers==3.5.1"
+        "!pip install transformers==4.3.0"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Old version of transformers library is depricated and breaks the code.
Version is updated in the readme and py notebook exampes.