### PR TITLE
resolved cuda and pytorch versions in rugpt3xl_generation notebook

### DIFF
--- a/examples/ruGPT3XL_generation.ipynb
+++ b/examples/ruGPT3XL_generation.ipynb
@@ -57,7 +57,8 @@
       "source": [
         "%%writefile setup.sh\n",
         "\n",
-        "export CUDA_HOME=/usr/local/cuda-10.1\n",
+        "pip install torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html\n",
+        "export CUDA_HOME=/usr/local/cuda-11.0\n",
         "git clone https://github.com/NVIDIA/apex\n",
         "pip install -v --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" ./apex"
       ],


### PR DESCRIPTION
Hi!
Tried to run `rugpt3xl_generation` notebook and got this error #49 
Solved by specifying pytorch and cuda versions to be installed that was mentioned #60:
```
pip install torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html
export CUDA_HOME=/usr/local/cuda-11.0
```
Also, this would be resolved #62 

Tested in colab, notebook works as expected.